### PR TITLE
More aliases for black/grey slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and you wanted to know the second to last guess you could run
 
 and it would print out `these`
 
-Note you can also use letters instead of the emojis, you can use b or w for the black (or white) squares then y for yellow and g for green.  
+Note you can also use letters instead of the emojis, you can use b or k (or w or even x) for the black (or white, i.e. not-in-the-word) squares then y for yellow and g for green.
 
 So if the word was "deton" and this was the pattern
 

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ const makeTests = (word, pattern) => {
 }
 function * makeGuesser (_word, _pattern, dict) {
   const word = _word.toUpperCase();
-  const pattern = _pattern.toLowerCase().replace(/[w\u{2B1B}\u{2B1C}]/gu, 'b')
+  const pattern = _pattern.toLowerCase().replace(/[kwx\u{2B1B}\u{2B1C}]/gu, 'b')
     .replace(/\u{1F7E9}/ug, 'g')
     .replace(/\u{1F7E8}/ug, 'y')
     if (!reg.exec(pattern)) {


### PR DESCRIPTION
This modifies the pattern canonicalizer to also treat "k" and "x" as representing a grey/black letter-not-in-word slot.

Rationale:

* `k` as in CMYK
* `x` as in "❌ nope/wrong"

~~(And apologies for not updating the documentation, just a quick change via GitHub website editor which I'm not super expert at :-)~~ README updated now too, hope the resulting wording isn't too wordy!